### PR TITLE
Fix for issue #4

### DIFF
--- a/lib/golden_brindle/start.rb
+++ b/lib/golden_brindle/start.rb
@@ -114,6 +114,8 @@ module Brindle
         options[:listeners] += listeners if listeners
       end
       app = RailsSupport.rails_builder(@daemon)
+      # load the app unless we want to preload it
+      app.call unless options[:preload_app]
       if @daemon
         Unicorn::Launcher.daemonize!(options)
       end


### PR DESCRIPTION
It looks like Unicorn expects the app to be loaded already if the preload_app flag isn't set. This flag just calls the lambda that is returned by RailsSupport#rails_builder to load the app.

If preload_app is true then Unicorn will call `build_app!` when it runs:

```
def build_app!
  if app.respond_to?(:arity) && app.arity == 0
    if defined?(Gem) && Gem.respond_to?(:refresh)
      logger.info "Refreshing Gem list"
      Gem.refresh
    end
    self.app = app.call
  end
end
```

If unicorn doesn't perform `build_app!` the next time `app` receives call is when it expects to call the rack handler itself in process_client:

```
def process_client(client)
  status, headers, body = @app.call(env = @request.read(client))

  if 100 == status.to_i
    client.write(Unicorn::Const::EXPECT_100_RESPONSE)
    env.delete(Unicorn::Const::HTTP_EXPECT)
    status, headers, body = @app.call(env)
  end
```

This is where the error was occuring.
