### PR TITLE
Support for amqp

### DIFF
--- a/lib/golden_brindle/hooks.rb
+++ b/lib/golden_brindle/hooks.rb
@@ -13,6 +13,14 @@ module GoldenBrindle
         defined?(ActiveRecord::Base) and
           ActiveRecord::Base.establish_connection
           # trying to change user and group
+		if Gem.available?("amqp")
+        	require "amqp"
+        	amqp_yaml = YAML.load_file("#{@cwd}/config/amqp.yml")
+        	amqp_config = amqp_yaml[ENV['RAILS_ENV'] || 'development']
+        	amqp_config.symbolize_keys!
+
+	    	t = Thread.new {AMQP.start(amqp_config)}
+	    end
         begin
           # check if something not set in config or cli
           unless @user.nil? || @group.nil?

--- a/resources/amqp.yml
+++ b/resources/amqp.yml
@@ -1,0 +1,49 @@
+# AMQP client configuration file
+
+# These values will be used to configure the ampq gem, any values
+# omitted will let the gem use it's own defaults.
+
+# The configuration specifies the following keys:
+# * user - Username for the broker
+# * pass - Password for the broker
+# * host     - Hostname where the broker is running
+# * vhost    - Vhost to connect to
+# * port     - Port where the broker is running
+# * ssl      - Use ssl or not
+# * timeout  - Timeout
+
+defaults: &defaults
+  user: user
+  pass: password
+  host: 127.0.0.1
+  vhost: your_vhost 
+  logging: false
+  heartbeat: 10
+  enabled: true
+
+production:
+  user: user
+  pass: password
+  host: 127.0.0.1
+  vhost: your_vhost 
+  logging: false
+  heartbeat: 10
+  enabled: true
+
+test:
+  user: user
+  pass: password
+  host: 127.0.0.1
+  vhost: your_vhost 
+  logging: false
+  heartbeat: 10
+  enabled: true
+
+demo:
+  <<: *production
+
+development:
+  <<: *defaults
+
+sandbox:
+  <<: *defaults


### PR DESCRIPTION
Recently, we have started using RabbitMQ and amqp and to make it work with Unicorn you have to establish the connections in the after_fork.  So, I've added a few lines to create the connections if the amqp gem exists and a sample YAML file to the resources dir.

Hope you find it useful
Ben
